### PR TITLE
endpoint to retrieve all modules show the module name as well

### DIFF
--- a/backend/controllers/moduleController.js
+++ b/backend/controllers/moduleController.js
@@ -16,8 +16,7 @@ const getModules = async (req, res) => {
 
     const modules = modulesSnapshot.docs.map((doc) => ({
       moduleCode: doc.id,
-      moduleName: doc.data().name,
-      weight: doc.data().weight,
+      moduleName: doc.data().moduleName,
       level: doc.data().level,
     }));
 

--- a/backend/controllers/moduleController.js
+++ b/backend/controllers/moduleController.js
@@ -7,10 +7,16 @@ const getModules = async (req, res) => {
     let query = db.collection("modules");
 
     // Handle level filtering
-    if (req.query.levels) {
-      const levels = req.query.levels.split(",").map(Number);
-      query = query.where("level", "in", levels);
+    if (req.query.level) {
+      const levels = req.query.level.split(",")
+        .map(level => parseInt(level, 10))
+        .filter(level => !isNaN(level));
+
+      if (levels.length > 0) {
+        query = query.where("level", "in", levels);
+      }
     }
+
 
     const modulesSnapshot = await query.get();
 

--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -10,7 +10,7 @@
       "license": "ISC",
       "dependencies": {
         "cors": "^2.8.5",
-        "dotenv": "^16.4.7",
+        "dotenv": "^16.5.0",
         "express": "^5.1.0",
         "firebase": "^11.6.0",
         "firebase-admin": "^13.2.0",
@@ -1393,9 +1393,9 @@
       }
     },
     "node_modules/dotenv": {
-      "version": "16.4.7",
-      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.4.7.tgz",
-      "integrity": "sha512-47qPchRCykZC03FhkYAhrvwU4xDBFIj1QPqaarj6mdM/hgUzfPHcpkHJOn3mJAufFeeAxAzeGsr5X0M4k6fLZQ==",
+      "version": "16.5.0",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.5.0.tgz",
+      "integrity": "sha512-m/C+AwOAr9/W1UOIZUo232ejMNnJAJtYQjUbHoNTBNTJSvqzzDh7vnrei3o3r3m9blf6ZoDkvcw0VmozNRFJxg==",
       "license": "BSD-2-Clause",
       "engines": {
         "node": ">=12"

--- a/backend/package.json
+++ b/backend/package.json
@@ -12,7 +12,7 @@
   "description": "",
   "dependencies": {
     "cors": "^2.8.5",
-    "dotenv": "^16.4.7",
+    "dotenv": "^16.5.0",
     "express": "^5.1.0",
     "firebase": "^11.6.0",
     "firebase-admin": "^13.2.0",


### PR DESCRIPTION
The endpoint GET /modules had some minor errors that prevent it from retrieving the name of each modules, it's solved now.